### PR TITLE
Current Twitter export files use "tweets" and not "tweet"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Go [here](https://twitter.com/settings/your_twitter_data).
 git clone git@github.com:FGRibreau/import-tweets-to-mastodon.git
 cd import-tweets-to-mastodon
 npm install
-MASTODON_API_BASEPATH=https://mastodon-instance.com MASTODON_API_KEY=YOUR_TOKEN TWITTER_TWEETJS_FILEPATH=/path/to/tweet.js node import.js
+MASTODON_API_BASEPATH=https://mastodon-instance.com MASTODON_API_KEY=YOUR_TOKEN TWITTER_TWEETJS_FILEPATH=/path/to/tweets.js node import.js
 ```
 
 Tips: add the `DEBUG=*` environment variable for verbose output.

--- a/import.js
+++ b/import.js
@@ -32,7 +32,7 @@ function getTweets() {
   const _global = {
     window: {
       YTD: {
-        tweet: {
+        tweets: {
           part0: {}
         }
       }
@@ -43,8 +43,8 @@ function getTweets() {
   const context = vm.createContext(_global);
   script.runInContext(context);
 
-  const tweets = Object.keys(_global.window.YTD.tweet.part0).reduce((m, key, i, obj) => {
-    return m.concat(_global.window.YTD.tweet.part0[key].tweet);
+  const tweets = Object.keys(_global.window.YTD.tweets.part0).reduce((m, key, i, obj) => {
+    return m.concat(_global.window.YTD.tweets.part0[key].tweet);
   }, []).filter(_keepTweet)
 
   debug('Loading %s tweets...', tweets.length);


### PR DESCRIPTION
Latest exports from Twitter use "tweets" and not "tweet" as the key in the data structure.