### PR TITLE
Make the "createMastodonPost" method asynchronous

### DIFF
--- a/import.js
+++ b/import.js
@@ -93,14 +93,15 @@ function replaceTwitterUrls(full_text, urls) {
   });
   return full_text;
 }
-function createMastodonPost({
+
+async function createMastodonPost({
   apiToken,
   baseURL
 }, {
   status,
   language
 }) {
-  return axios({
+  return await axios({
     url: '/api/v1/statuses',
     baseURL: baseURL,
     method: 'POST',


### PR DESCRIPTION
By making the method asynchronous, it will no longer need to wait for the completion of a post to start the action of another.