### PR TITLE
Fix: Run Import

### DIFF
--- a/import.js
+++ b/import.js
@@ -86,6 +86,8 @@ function importTweets(tweets) {
       console.log(err);
     });
   }
+
+  next();
 }
 function replaceTwitterUrls(full_text, urls) {
   urls.forEach(url => {


### PR DESCRIPTION
at least for Windows, the `next` function must be called initially in order to call itself afterwards.